### PR TITLE
Legal page after sign in first time added

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -10,6 +10,10 @@ const routes: Routes = [
     path: 'tabs',
     loadChildren: () => import('./tabs/tabs.module').then(m => m.TabsPageModule)
   },
+  {
+    path: 'legal-popup',
+    loadChildren: () => import('./pages/legal-popup/legal-popup.module').then( m => m.LegalPopupPageModule)
+  },
 ];
 @NgModule({
   imports: [

--- a/src/app/pages/legal-popup/legal-popup-routing.module.ts
+++ b/src/app/pages/legal-popup/legal-popup-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { LegalPopupPage } from './legal-popup.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: LegalPopupPage
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class LegalPopupPageRoutingModule {}

--- a/src/app/pages/legal-popup/legal-popup.module.ts
+++ b/src/app/pages/legal-popup/legal-popup.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { IonicModule } from '@ionic/angular';
+
+import { LegalPopupPageRoutingModule } from './legal-popup-routing.module';
+
+import { LegalPopupPage } from './legal-popup.page';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    LegalPopupPageRoutingModule,
+    LegalPopupPage,
+  ],
+})
+export class LegalPopupPageModule {}

--- a/src/app/pages/legal-popup/legal-popup.page.html
+++ b/src/app/pages/legal-popup/legal-popup.page.html
@@ -1,0 +1,135 @@
+<ion-header>
+    <ion-toolbar>
+        <ion-title style="text-align: center;"> Legal Disclaimer </ion-title>
+    </ion-toolbar>
+</ion-header>
+
+<ion-content class="ion-padding">
+    <h1>TERMS AND CONDITIONS</h1>
+
+    <p>
+    Smooth Migration Inc. (Smooth Migration) and its members, officers, directors, owners, employees, agents, representatives, suppliers, and service providers (collectively “Smooth Migration”) provides this website (the “Site”) for informational purposes only. Use of and access to the Site and the information, materials, services, and other content available on or through the Site (“Content”) are subject to these terms of use and all applicable laws.
+    </p>
+
+    <h1>OFFER PERIOD:</h1>
+
+    <p>
+    From Nov 1 2022 – April 30 2023, To qualify for the Chequing Account Offer you must open a valid chequing account, provide a valid email address, make a deposit of any amount by April 30, 2023, and complete at least two of the following actions: set up recurring direct deposit, make one eligible bill payment of at least $50 through BMO Online banking or the Mobile app, or set up one pre-authorized debit of at least $50.
+    </p>
+
+    <h1>THIRD PARTY LINKED SITES</h1>
+
+    <p>
+    As a convenience to you, Smooth Migration may provide hyperlinks to web sites operated by third parties. When you select these hyperlinks, you will be leaving the Smooth Migration site. Because Smooth Migration has no control over such sites or their content, Smooth Migration is not responsible for the availability of such external sites or their content, and Smooth Migration does not adopt, endorse or nor is responsible or liable for any such sites or content, including advertising, products, or other materials, on or available through such sites or resources. Other web sites may provide links to the Site or Content with or without our authorization. Smooth Migration does not endorse such sites and shall not be responsible or liable for any links from those sites to the Site or Content, or for any content, advertising, products, or other materials available on or through such other sites, or any loss or damages incurred in connection therewith. Smooth Migration may, in its sole discretion, block links to the Site and Content without prior notice.
+    </p>
+
+    <p>
+    YOUR USE OF THIRD-PARTY WEB SITES AND CONTENT, INCLUDING WITHOUT LIMITATION, YOUR USE OF ANY INFORMATION, DATA, ADVERTISING, PRODUCTS, OR OTHER MATERIALS ON OR AVAILABLE THROUGH SUCH WEB SITES, IS AT YOUR OWN RISK AND IS SUBJECT TO THEIR TERMS OF USE.
+    </p>
+
+    <h1>USE OF COOKIES</h1>
+
+    <p>
+    Smooth Migration’s website utilizes different technologies to collect, store, and aggregate data about website usage. We may use electronic tags called “cookies” to help us understand and analyze use of our site. This work is either performed directly by us or by a third party we have hired to assist us. We collect information about which pages have that been accessed and for how long, the country the user accesses the site from, and certain technical information regarding the user’s computer and operating systems, such as user Internet protocol address, domain name and browser, etc.
+    </p>
+
+    <p>
+    Certain sections of Smooth Migration’s site require cookies to be enabled to enhance site performance. For example, cookies provide a secure way for us to verify user identity during a session and any return visits, they enable us to personalize a user’s experience on our sites, and they help enhance site navigation. Cookies also help us to understand how people use our sites so we can improve site functionality.
+    </p>
+
+    <p>
+    When a user comes to the website, our server sends a cookie to the user’s computer. Stand-alone, cookies do not identify the user personally; they merely recognize the user’s browser. Personally identifiable information is obtained by us only when a user decides to provide it, such as when requesting additional information via email or providing personal information.
+    </p>
+
+    <p>
+    We use two types of cookies on our sites, temporary cookies, and persistent cookies. Temporary cookies are used to store information during a browser session and will expire shortly after concluding a visit to one of our sites. Persistent cookies are used to store information between visits to one of our sites and are stored permanently or for a specified length of time. Persistent cookies are used to facilitate easier navigation within our sites and provide a higher level of convenience for the user.
+    </p>
+
+    <p>
+    A user can choose to have their computer issue a warning each time a cookie is being sent, or a user can choose to turn off all cookies. The management of cookies is handled through the user’s browser settings (e.g., Internet Explorer). To obtain more information about managing cookies, visit www.aboutcookies.org.
+    </p>
+
+
+    <h1>SITE AND CONTENT NOT WARRANTED</h1>
+
+    <p>
+    THE SITE AND CONTENT, ARE PROVIDED “AS IS” AND WITHOUT WARRANTIES OF ANY KIND. YOU BEAR ALL RISKS ASSOCIATED WITH THE USE OF THE SITE AND CONTENT, INCLUDING WITHOUT LIMITATION, ANY RELIANCE ON THE ACCURACY, COMPLETENESS OR USEFULNESS OF ANY CONTENT AVAILABLE ON THE SITE. Smooth Migration AND ITS EMPLOYEES, OFFICERS, DIRECTORS, PARTNERS, AGENTS, REPRESENTATIVES, SUPPLIERS AND SERVICE PROVIDERS, DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION, ALL WARRANTIES OF TITLE, NON-INFRINGEMENT, ACCURACY, COMPLETENESS, USEFULNESS, MERCHANTABILITY, AND FITNESS FOR A PARTICULAR USE, AND WARRANTIES THAT MAY ARISE FROM COURSE OF DEALING/PERFORMANCE OR USAGE OF TRADE.
+    </p>
+
+    <h1>LIMITATION OF LIABILITY</h1>
+
+    <p>
+    YOUR EXCLUSIVE REMEDY FOR DISSATISFACTION WITH THE SITE AND CONTENT IS TO STOP USING THE SITE AND CONTENT. Smooth Migration IS NOT LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, CONSEQUENTIAL, SPECIAL OR PUNITIVE DAMAGES, UNDER ANY THEORY OF LIABILITY, INCLUDING WITHOUT LIMITATION, DAMAGES FOR LOSS OF PROFITS, USE, DATA, OR LOSS OF OTHER INTANGIBLES. IN PARTICULAR, AND WITHOUT LIMITATION, Smooth Migration WILL NOT BE LIABLE FOR DAMAGES OF ANY KIND RESULTING FROM YOUR USE OF OR INABILITY TO USE THE SITE OR CONTENT.
+    </p>
+
+    <p>
+    While we try to maintain the integrity and security of the Site and the servers from which the Site is operated, we do not guarantee that the Site or Content is or remains secure, complete, or correct, or that access to the Site or Content will be uninterrupted or error free. The Site and Content may include inaccuracies, errors and materials that violate or conflict with these Terms. Additionally, third parties may make unauthorized alterations to the Site or Content. If you become aware of any unauthorized third party alteration to the Site or Content, contact us at contact&#64;smoothmigration.net with a description of the material(s) at issue and the URL.
+    </p>
+
+    <h1>NOTICES, COMMUNICATIONS, AND ELECTRONIC SIGNATURES</h1>
+
+    <p>
+    You agree to be bound by any affirmation, assent or agreement that you transmit on or through the Site or any other aspect of Smooth Migration’s services that you access by computer or other electronic device, including internet, telephonic and wireless devices, including but not limited to any consent you give to receive communications from us solely through electronic transmission. You agree that, when in the future you click on a “Submit” or “I agree” or other similarly worded “button” or entry field with your mouse, keystroke or other device, your agreement or consent will be legally binding and enforceable and the legal equivalent of your handwritten signature.
+    </p>
+
+    <h1>LIMITED RIGHT OF USE/OWNERSHIP OF CONTENT</h1>
+
+    <p>
+    You are permitted to use the Site and Content for your personal, non-commercial use only. The Site and Content are and shall remain the property of Smooth Migration and is protected by copyright, trademark, patent, and/or other intellectual property, proprietary, work product rights and laws. You may use the Site and Content for your personal, noncommercial use, provided that you keep intact all copyright, trademark, patent and other proprietary notices. Except as expressly authorized in advance by Smooth Migration in writing, you agree not to reproduce, modify, or create derivative works based on, rent, lease, loan, sell, distribute, publish, publicly perform, or display, reverse engineer, de-compile or dissemble, all or any part of the Site or Content.
+    </p>
+
+    <p>
+    Trade names, trademarks and service marks of Smooth Migration include, without limitation, Smooth Migration, and any associated logos. All trademarks and service marks on the Site not owned by Smooth Migration are the property of their respective owners. Nothing contained on the Site should be construed as granting, by implication, estoppel or otherwise, any license or right to use any of Smooth Migration’s trade names, trademarks, or service marks without our express prior written consent.
+    </p>
+
+    <h1>TERMINATION</h1>
+
+    <p>
+    Smooth Migration, in its sole discretion, may terminate your access to or use of the Site and Content, at any time and for any reason. Your access to or use of the Site and Content may be terminated without notice. Smooth Migration shall not be liable to you or any third party for any termination of your access to the Site or Content, or to any such information or files, and shall not be required to make such information or files available to you after any such termination.
+    </p>
+
+    <h1>RULES OF CONDUCT</h1>
+
+    <p>
+    Your use of the Site and Content is conditioned on your compliance with the rules of conduct set forth here. You will not:
+    </p>
+
+    <ul>
+        <li>Use the Site or Content for any fraudulent or unlawful purpose.</li>
+        <li>Interfere with or disrupt the operation of the Site or Content or the servers or networks used to make the Site and Content available; or violate any requirements, procedures, policies, or regulations of such networks.</li>
+        <li>Restrict or inhibit any other person from using the Site or Content (including without limitation by hacking or defacing any portion of the Site or Content).</li>
+        <li>Use the Site or Content to advertise or offer to sell or buy any goods or services without Smooth Migration’s express prior written consent.</li>
+        <li>Reproduce, duplicate, copy, sell, resell, or otherwise exploit for any commercial purposes, any portion of, use of, or access to the Site or Content.</li>
+        <li>Modify, adapt, reverse engineer, de-compile/disassemble any part of the Site or Content.</li>
+        <li>Remove any copyright, trademark or other proprietary rights notice from the Site or materials originating from the Site or Content.</li>
+        <li>Frame or mirror any part of the Site or Content without Smooth Migration’s express prior written consent.</li>
+        <li>Create a database by systematically downloading and storing Content.</li>
+        <li>Use any robot, spider, site search/retrieval application or other manual or automatic device to retrieve, index, “scrape,” “data mine” or in any way gather Content or reproduce or circumvent the navigational structure or presentation of the Site without Company’s express prior written consent.</li>
+    </ul>
+    <h1>INDEMNIFICATION</h1>
+
+    <p>
+    By accessing and using the Site and Content, you agree to indemnify, defend and hold harmless Smooth Migration (specifically including its officers, directors, owners, partners, employees, agents, information providers, licensors and licensees) (collectively, the “Indemnified Parties”) from and against any and all claims, losses, costs and expenses (including attorneys’ fees) arising out of or relating to (a) any breach (or claim, that if true, would be a breach) by you of these Terms and (b) your use of or activities in connection with the Site. We reserve the right, at our own expense, to assume the exclusive defense and control of any matter otherwise subject to indemnification by you. You shall not enter into any settlement agreement which affects the rights of any of the Indemnified Parties or requires the taking of any action by any of them, without our prior written approval.
+    </p>
+
+    <h1>JURISDICTIONAL CONTEXT</h1>
+
+    <p>
+    The Site is controlled and operated by Smooth Migration from the United States and is not intended to subject Smooth Migration to the laws or jurisdiction of any country or territory other than that of the United States.  Smooth Migration does not represent or warrant that the Site or any part thereof is appropriate or available for use in any particular jurisdiction other than the United States and only in those US states and territories where Smooth Migration is registered or licensed or exempt from registration or licensing under applicable state or federal law. In choosing to access the Site, you do so on your own initiative and at your own risk, and you are responsible for complying with all local laws, rules, and regulations. We may limit the Site’s availability to any person, geographic area, or jurisdiction.
+    </p>
+
+    <h1>MODIFICATIONS</h1>
+
+    <p>
+    Smooth Migration may amend the terms of use at any time in its discretion, by posting revisions on the Site.
+    </p>
+</ion-content>
+
+<ion-footer>
+    <ion-toolbar>
+        <div class="choices">
+            <ion-button (click)="acceptClick()" id="accept-button" disabled>Accept</ion-button>
+            <ion-button (click)="declineClick()">Decline</ion-button>
+        </div>
+    </ion-toolbar>
+</ion-footer>

--- a/src/app/pages/legal-popup/legal-popup.page.scss
+++ b/src/app/pages/legal-popup/legal-popup.page.scss
@@ -1,0 +1,20 @@
+ion-content {
+  --padding-bottom: 10px;
+  --padding-end: 40px;
+  --padding-start: 40px;
+  --padding-top: 20px;
+}
+
+.choices {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  column-gap: 10%;
+  padding-bottom: 25px;
+  padding-top: 15px;
+}
+
+.choices ion-button {
+  transition: all 0.7s ease;
+}

--- a/src/app/pages/legal-popup/legal-popup.page.spec.ts
+++ b/src/app/pages/legal-popup/legal-popup.page.spec.ts
@@ -1,0 +1,17 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LegalPopupPage } from './legal-popup.page';
+
+describe('LegalPopupPage', () => {
+  let component: LegalPopupPage;
+  let fixture: ComponentFixture<LegalPopupPage>;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LegalPopupPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/legal-popup/legal-popup.page.ts
+++ b/src/app/pages/legal-popup/legal-popup.page.ts
@@ -1,0 +1,41 @@
+import { Component, AfterViewInit, ViewChild } from '@angular/core';
+import { Router } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { IonicModule, IonContent } from '@ionic/angular';
+
+@Component({
+  selector: 'app-legal-popup',
+  templateUrl: './legal-popup.page.html',
+  styleUrls: ['./legal-popup.page.scss'],
+  imports: [CommonModule, IonicModule],
+})
+export class LegalPopupPage implements  AfterViewInit {
+  @ViewChild(IonContent) scrollableContent!: IonContent;
+
+  constructor(private router: Router) { }
+
+  ngAfterViewInit() {
+      let acceptButton = document.getElementById('accept-button');
+      this.scrollableContent?.getScrollElement().then(sc => {
+          sc.addEventListener('scroll', () => {
+              if (this.isAtBottom(sc)) {
+                  acceptButton?.removeAttribute('disabled');
+              }
+          });
+      });
+  }
+
+  isAtBottom(scrollable_content: HTMLElement): boolean {
+      if (!scrollable_content) {return false;}
+      return scrollable_content.scrollHeight - scrollable_content.scrollTop <= scrollable_content.clientHeight + 10;
+  }
+
+  public acceptClick() {
+      this.router.navigate(['/tabs']);
+  }
+
+  public declineClick() {
+      this.router.navigate(['/']);
+  }
+
+}

--- a/src/app/pages/login/login.page.ts
+++ b/src/app/pages/login/login.page.ts
@@ -33,11 +33,12 @@ export class LoginPage implements OnInit {
       // the user has already signed in before
   }
 
-  forgot_email_password() {
+  public forgot_email_password() {
       //TODO: Open Smooth Migration Forgot email/password web page
+      console.log("forgot email-password pressed");
   }
 
-  login() {
+  public login() {
       /*
        * this.email, this.password -> class variables pointing to input form value, updated at login button press
        * this.emailError, this.passwordError -> binded property from html, links value there with error message we set here
@@ -58,7 +59,11 @@ export class LoginPage implements OnInit {
           //TODO: API Check for account
           // email && password are actual account
           if (this.password === "root") {
-              this.router.navigate(['/tabs']);
+              if (1 === 1 /* Individual has never signed in before, open legal */) {
+                  this.router.navigate(['/legal-popup']);
+              } else { /* Signed in before, just go to tabs */
+                  this.router.navigate(['/tabs']);
+              }
           } else {
               this.emailError = "Account not found";
               this.passwordError = "Account not found";
@@ -74,8 +79,9 @@ export class LoginPage implements OnInit {
       }
   }
 
-  register() {
+  public register() {
       //TODO: Open SmoothMigration account registry web page
+      console.log("forgot register pressed");
   }
 
 }

--- a/src/app/pages/login/login.page.ts
+++ b/src/app/pages/login/login.page.ts
@@ -58,12 +58,15 @@ export class LoginPage implements OnInit {
       if (this.loginForm.valid) {
           //TODO: API Check for account
           // email && password are actual account
-          if (this.password === "root") {
+          if (this.password === "test") {
               if (1 === 1 /* Individual has never signed in before, open legal */) {
+                  //REMOVE: Get rid of the queryParams part once we have user authentication
                   this.router.navigate(['/legal-popup']);
               } else { /* Signed in before, just go to tabs */
                   this.router.navigate(['/tabs']);
               }
+          } else if (this.password === "root") {
+                this.router.navigate(['/tabs']);
           } else {
               this.emailError = "Account not found";
               this.passwordError = "Account not found";


### PR DESCRIPTION
Legal Page (after signin)
---
- Added smooth migration legality page after sign in
  - Page pops up and must scroll to accept, will then take to tabs page
  - Still need to combine with authentication functionality to check if signed in before.  If so, don't need to show legal page
  - If signed in with password root, will skip page.  **Use password 'test' to see page**